### PR TITLE
dockerfileの追加

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,0 +1,16 @@
+
+# # tensorflow use CPU
+# FROM tensorflow/tensorflow:latest
+
+# tensorflow use GPU
+# "docker run" requires "--gpus" option 
+FROM tensorflow/tensorflow:latest-gpu 
+
+# copy python requirements.txt file
+COPY requirements.txt /root/
+
+# installing python modules
+RUN apt-get update
+RUN pip install --upgrade pip
+RUN pip install --upgrade setuptools
+RUN pip install -r /root/requirements.txt

--- a/dockerfile
+++ b/dockerfile
@@ -3,7 +3,10 @@
 # FROM tensorflow/tensorflow:latest
 
 # tensorflow use GPU
-# "docker run" requires "--gpus" option 
+# NOTE: 
+#   Two requirements to enable GPU in containers.
+#   1. GPU drivers and CUDA are installed on the host OS.
+#   2. Use "--gpus" option with "docker run".
 FROM tensorflow/tensorflow:latest-gpu 
 
 # copy python requirements.txt file

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy
 pandas
 tensorflow
-sklearn
 scikit-learn
 matplotlib
 seaborn
@@ -9,3 +8,5 @@ h5py
 scipy
 simplejson
 optuna
+
+


### PR DESCRIPTION
すぐにコードを試すことができるようにするためにdockerfileを追加する。
python requirements.txt内に無効なモジュール名があり、pip installが失敗するので、それを除去した。
