### PR TITLE
remove deprecated module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 numpy
 pandas
 tensorflow
-sklearn
 scikit-learn
 matplotlib
 seaborn


### PR DESCRIPTION
Remove "sklearn" from requirement.txt.
"sklearn" is deprecated.
https://pypi.org/project/sklearn/